### PR TITLE
Compile and add org/w3c/dom/ElementTraversal.class to xercesImpl.jar.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -309,6 +309,19 @@ Authors:
                 org/w3c/dom/views/**
                 org/w3c/dom/xpath/**"
            />
+    <xjavac srcdir="${build.src}"
+           destdir="${build.dest}"
+           source="${javac.source}"
+           target="${javac.target}"
+           classpath="${build.dir}/classes:${tools.dir}/${jar.apis}:${tools.dir}/${jar.resolver}:${tools.dir}/${jar.serializer}"
+           debug="${debug}"
+           debuglevel="${debuglevel}"
+           deprecation="${deprecation}"
+           optimize="${optimize}"
+           includeAntRuntime="false"
+           includeJavaRuntime="false"
+           includes="org/w3c/dom/ElementTraversal.java"
+           />
   </target>
 
   <!-- =================================================================== -->
@@ -337,7 +350,7 @@ Authors:
          basedir="${build.dest}"
          compress="true"
          includes="org/apache/**, META-INF/**
-                   org/w3c/dom/html/HTMLDOMImplementation.class"
+                   org/w3c/dom/html/HTMLDOMImplementation.class, org/w3c/dom/ElementTraversal.class"
          manifest="${build.dir}/manifest.xerces">
       <manifest>
         <attribute name="Ant-Version" value="${ant.version}"/>


### PR DESCRIPTION
Needed to use this version based on xerces-2.11 in wildfly-core and wildfly 8.x.
See https://github.com/wildfly/wildfly-core/pull/493 and https://github.com/wildfly/wildfly/pull/7165.
