### PR TITLE
Some bugfixes related to Grammar Pooling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>xerces</groupId>
   <artifactId>xercesImpl</artifactId>
-  <version>2.11.0.SP4-SNAPSHOT</version>
+  <version>2.11.0.SP4</version>
   <packaging>jar</packaging>
 
   <name>Xerces-J</name>
@@ -71,7 +71,7 @@
     <connection>scm:git:https://github.com/jboss/xerces</connection>
     <developerConnection>scm:git:git@github.com:jboss/xerces.git</developerConnection>
     <url>https://github.com/jboss/xerces</url>
-    <tag>HEAD</tag>
+    <tag>jboss-2.11.0.SP4</tag>
   </scm>
   <issueManagement />
   <ciManagement />

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>xerces</groupId>
   <artifactId>xercesImpl</artifactId>
-  <version>2.11.0.SP4</version>
+  <version>2.11.0.SP5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Xerces-J</name>
@@ -71,7 +71,7 @@
     <connection>scm:git:https://github.com/jboss/xerces</connection>
     <developerConnection>scm:git:git@github.com:jboss/xerces.git</developerConnection>
     <url>https://github.com/jboss/xerces</url>
-    <tag>jboss-2.11.0.SP4</tag>
+    <tag>HEAD</tag>
   </scm>
   <issueManagement />
   <ciManagement />

--- a/src/org/apache/xerces/impl/XMLEntityManager.java
+++ b/src/org/apache/xerces/impl/XMLEntityManager.java
@@ -44,6 +44,8 @@ import org.apache.xerces.impl.io.UTF16Reader;
 import org.apache.xerces.impl.io.UTF8Reader;
 import org.apache.xerces.impl.msg.XMLMessageFormatter;
 import org.apache.xerces.impl.validation.ValidationManager;
+import org.apache.xerces.impl.dtd.DTDGrammar;
+import org.apache.xerces.impl.dtd.XMLEntityDecl;
 import org.apache.xerces.util.AugmentationsImpl;
 import org.apache.xerces.util.EncodingMap;
 import org.apache.xerces.util.HTTPInputSource;
@@ -2333,6 +2335,29 @@ public class XMLEntityManager
     Hashtable getDeclaredEntities() {
         return fEntities;
     } // getDeclaredEntities():Hashtable
+
+    public void initFromDTD(DTDGrammar grammar)
+    {
+        final XMLEntityDecl entityDecl = new XMLEntityDecl();
+        int index = 0;
+     
+        while(grammar.getEntityDecl(index++, entityDecl)) {
+          fInExternalSubset = entityDecl.inExternal;
+          if(entityDecl.inExternal) {
+            if(entityDecl.publicId != null
+                || entityDecl.systemId != null) {
+                try {
+                    addExternalEntity(entityDecl.name, entityDecl.publicId, entityDecl.systemId, entityDecl.baseSystemId);
+                }
+                catch(IOException e) {
+                }
+            } else {
+                addInternalEntity(entityDecl.name, entityDecl.value);
+            }
+          }
+        }
+        fInExternalSubset = false;
+    }
 
     /** Prints the contents of the buffer. */
     static final void print(ScannedEntity currentEntity) {

--- a/src/org/apache/xerces/impl/dtd/XMLDTDValidator.java
+++ b/src/org/apache/xerces/impl/dtd/XMLDTDValidator.java
@@ -143,6 +143,10 @@ public class XMLDTDValidator
     protected static final String VALIDATION_MANAGER =
         Constants.XERCES_PROPERTY_PREFIX + Constants.VALIDATION_MANAGER_PROPERTY;
 
+    /** Property identifier: entity manager. */
+    protected static final String ENTITY_MANAGER =
+        Constants.XERCES_PROPERTY_PREFIX + Constants.ENTITY_MANAGER_PROPERTY;
+
     // recognized features and properties
 
     /** Recognized features. */
@@ -193,6 +197,9 @@ public class XMLDTDValidator
 
     // updated during reset
     protected ValidationManager fValidationManager = null;
+
+    /** Entity manager. */
+    protected XMLEntityManager fEntityManager;
     
     // validation state
     protected final ValidationState fValidationState = new ValidationState();
@@ -503,6 +510,8 @@ public class XMLDTDValidator
         fValidationManager= (ValidationManager)componentManager.getProperty(VALIDATION_MANAGER);
         fValidationManager.addValidationState(fValidationState);      
         fValidationState.setUsingNamespaces(fNamespaces);
+
+        fEntityManager = (XMLEntityManager)componentManager.getProperty(ENTITY_MANAGER);
         
         // get needed components
         fErrorReporter = (XMLErrorReporter)componentManager.getProperty(Constants.XERCES_PROPERTY_PREFIX+Constants.ERROR_REPORTER_PROPERTY);
@@ -761,6 +770,8 @@ public class XMLDTDValidator
             // we've found a cached one;so let's make sure not to read
             // any external subset!
             fValidationManager.setCachedDTD(true);
+
+            fEntityManager.initFromDTD(fDTDGrammar);
         }
         fGrammarBucket.setActiveGrammar(fDTDGrammar);
 

--- a/src/org/apache/xerces/impl/dv/xs/TimeDV.java
+++ b/src/org/apache/xerces/impl/dv/xs/TimeDV.java
@@ -78,7 +78,6 @@ public class TimeDV extends AbstractDateTimeDV {
         
         if ( date.utc!=0 && date.utc != 'Z') {
             normalize(date);
-            date.day = 15;
         }
         date.position = 2;
         return date;

--- a/src/org/apache/xerces/xinclude/XIncludeHandler.java
+++ b/src/org/apache/xerces/xinclude/XIncludeHandler.java
@@ -53,6 +53,7 @@ import org.apache.xerces.xni.XMLLocator;
 import org.apache.xerces.xni.XMLResourceIdentifier;
 import org.apache.xerces.xni.XMLString;
 import org.apache.xerces.xni.XNIException;
+import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xerces.xni.parser.XMLComponent;
 import org.apache.xerces.xni.parser.XMLComponentManager;
 import org.apache.xerces.xni.parser.XMLConfigurationException;
@@ -208,6 +209,10 @@ public class XIncludeHandler
     protected static final String JAXP_SCHEMA_LANGUAGE =
         Constants.JAXP_PROPERTY_PREFIX + Constants.SCHEMA_LANGUAGE;
     
+    /** Property identifier: grammar pool. */
+    protected static final String GRAMMAR_POOL = 
+        Constants.XERCES_PROPERTY_PREFIX + Constants.XMLGRAMMAR_POOL_PROPERTY;
+
     /** Property identifier: symbol table. */
     protected static final String SYMBOL_TABLE = 
         Constants.XERCES_PROPERTY_PREFIX + Constants.SYMBOL_TABLE_PROPERTY;
@@ -282,6 +287,7 @@ public class XIncludeHandler
     protected XMLLocatorWrapper fXIncludeLocator = new XMLLocatorWrapper();
     protected XIncludeMessageFormatter fXIncludeMessageFormatter = new XIncludeMessageFormatter();
     protected XIncludeNamespaceSupport fNamespaceContext;
+    protected XMLGrammarPool fGrammarPool;
     protected SymbolTable fSymbolTable;
     protected XMLErrorReporter fErrorReporter;
     protected XMLEntityResolver fEntityResolver;
@@ -467,6 +473,21 @@ public class XIncludeHandler
             fFixupLanguage = true;
         }
         
+        // Get grammar pool.
+        try {
+            XMLGrammarPool value =
+                (XMLGrammarPool)componentManager.getProperty(GRAMMAR_POOL);
+            if (value != null) {
+                fGrammarPool = value;
+                if (fChildConfig != null) {
+                    fChildConfig.setProperty(GRAMMAR_POOL, value);
+                }
+            }
+        }
+        catch (XMLConfigurationException e) {
+            fGrammarPool = null;
+        }
+        
         // Get symbol table.
         try {
             SymbolTable value =
@@ -650,6 +671,13 @@ public class XIncludeHandler
      */
     public void setProperty(String propertyId, Object value)
         throws XMLConfigurationException {
+        if (propertyId.equals(GRAMMAR_POOL)) {
+            fGrammarPool = (XMLGrammarPool)value;
+            if (fChildConfig != null) {
+                fChildConfig.setProperty(propertyId, value);
+            }
+            return;
+        }
         if (propertyId.equals(SYMBOL_TABLE)) {
             fSymbolTable = (SymbolTable)value;
             if (fChildConfig != null) {
@@ -1598,6 +1626,7 @@ public class XIncludeHandler
                         true);
 
                 // use the same symbol table, error reporter, entity resolver, security manager and buffer size.
+                if (fGrammarPool != null) fChildConfig.setProperty(GRAMMAR_POOL, fGrammarPool);
                 if (fSymbolTable != null) fChildConfig.setProperty(SYMBOL_TABLE, fSymbolTable);
                 if (fErrorReporter != null) fChildConfig.setProperty(ERROR_REPORTER, fErrorReporter);
                 if (fEntityResolver != null) fChildConfig.setProperty(ENTITY_RESOLVER, fEntityResolver);


### PR DESCRIPTION
Hi there,

since you are basically managing the only active maintenance development of Xerces, I thought you might want to consider pulling in some patches that I found to be tremendously useful (but are not fixed in the official Xerces-J yet).

They are both somehow related to grammar pooling, something that is quite useful to massively improve the performance of systems that are doing large scale XML processing.

These patches are:
https://issues.apache.org/jira/browse/XERCESJ-1205
https://issues.apache.org/jira/browse/XERCESJ-1645

Hope you find them useful!
