### PR TITLE
apply XERCESJ-1667 fix

### DIFF
--- a/src/org/apache/xerces/dom/DOMNormalizer.java
+++ b/src/org/apache/xerces/dom/DOMNormalizer.java
@@ -152,7 +152,12 @@ public class DOMNormalizer implements XMLDocumentHandler {
     /**
      * If the user stops the process, this exception will be thrown.
      */
-    public static final RuntimeException abort = new RuntimeException();
+    public static final RuntimeException abort = new RuntimeException() {
+        private static final long serialVersionUID = 5361322877988412432L;
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+    };
     
     /** Empty string to pass to the validator. **/
     public static final XMLString EMPTY_STRING = new XMLString();


### PR DESCRIPTION
XERCESJ-1667 fix is part of the trunk but was never released under 2.11
please apply the fix to resolve any potential classloader leaks.

see:
https://issues.apache.org/jira/browse/XERCESJ-1667
https://svn.apache.org/repos/asf/xerces/java/trunk/src/org/apache/xerces/dom/DOMNormalizer.java