### PR TITLE
JBEAP-8362 - TransformerFactory doesn't propogate SECURE_PROCESSING feature to DocumentBuilderFactory/SAXParser it creates

### DIFF
--- a/src/org/apache/xerces/jaxp/DocumentBuilderFactoryImpl.java
+++ b/src/org/apache/xerces/jaxp/DocumentBuilderFactoryImpl.java
@@ -74,9 +74,10 @@ public class DocumentBuilderFactoryImpl extends DocumentBuilderFactory {
     private boolean isXIncludeAware;
     
     /**
-     * State of the secure processing feature, initially <code>false</code>
+     * State of the secure processing feature, initially <code>true</code>
      */
-    private boolean fSecureProcess = false;
+    public static boolean SECURE_PROCESS_DEFAULT = true;
+    private boolean fSecureProcess = SECURE_PROCESS_DEFAULT;
 
     /**
      * Creates a new instance of a {@link javax.xml.parsers.DocumentBuilder}

--- a/src/org/apache/xerces/jaxp/SAXParserFactoryImpl.java
+++ b/src/org/apache/xerces/jaxp/SAXParserFactoryImpl.java
@@ -59,9 +59,9 @@ public class SAXParserFactoryImpl extends SAXParserFactory {
     private boolean isXIncludeAware;
     
     /**
-     * State of the secure processing feature, initially <code>false</code>
+     * State of the secure processing feature, initially <code>true</code>
      */
-    private boolean fSecureProcess = false;
+    private boolean fSecureProcess = true;
 
     /**
      * Creates a new instance of <code>SAXParser</code> using the currently


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-8362
Upstream Issue (sort of): https://issues.jboss.org/browse/WFCORE-4023 
