### PR TITLE
[JBEAP-19976][JBEAP-19977][JBEAP-19978] XML validation manipulation due to incomplete application of use-grammar-pool-only in xercesImpl

### DIFF
--- a/src/org/apache/xerces/impl/xs/XMLSchemaValidator.java
+++ b/src/org/apache/xerces/impl/xs/XMLSchemaValidator.java
@@ -1900,7 +1900,7 @@ public class XMLSchemaValidator
 
         // root element
         if (fElementDepth == -1 && fValidationManager.isGrammarFound()) {
-            if (fSchemaType == null) {
+            if (fSchemaType == null && !fUseGrammarPoolOnly) {
                 // schemaType is not specified
                 // if a DTD grammar is found, we do the same thing as Dynamic:
                 // if a schema grammar is found, validation is performed;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-19976
https://issues.redhat.com/browse/JBEAP-19977
https://issues.redhat.com/browse/JBEAP-19978